### PR TITLE
add uni.py for hierarchical pdf/epub structure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,13 @@ wordcheck:
 wc:
 	@wc $(MDS)
 
-epub:
-	pandoc -o uncurled.epub --epub-cover-image=uncurled.jpg epub.txt $(MDS)
+uni.md:
+	./uni.py $(MDS)
 
-pdf:
-	pandoc -o uncurled.pdf pdf.txt $(MDS)
+epub: uni.md
+	pandoc -o uncurled.epub --epub-cover-image=uncurled.jpg epub.txt uni.md
+	rm uni.md
+
+pdf: uni.md
+	pandoc -o uncurled.pdf pdf.txt uni.md
+	rm uni.md

--- a/uni.py
+++ b/uni.py
@@ -4,6 +4,19 @@ import re
 import sys
 
 
+def get_first_anchor(path):
+    f = open(path)
+    while(1):
+        l = f.readline()
+        if not l:
+            break
+        elif re.match("#+ ", l):
+            f.close()
+            return '#' + (l[l.find(' ')+1:-1]).lower().replace(' ', '-')
+    f.close()
+    return '#'
+
+
 def uni_file(path, n=0):
     f = open(path)
     content = f.readlines()
@@ -16,6 +29,16 @@ def uni_file(path, n=0):
             ref_path = ref_path[1:-1]
             new_content += ['\n']
             new_content += uni_file(ref_path, n+1)
+        elif re.search("\[.+\]\(.+\.md\)", i):
+            ref = re.search("\[.+\]\(.+\.md\)", i)
+            start = ref.start()
+            end = ref.end()
+            ref_path = ref.group()
+            ref_path = ref_path[ref_path.find('(')+1:-1]
+            if path.rfind('/') != -1:
+                ref_path = path[:path.rfind('/')] + '/' + ref_path
+            new_line = i[:i.find('(', start)+1]+get_first_anchor(ref_path)+i[end-1:]
+            new_content.append(new_line)
         else:
             new_content.append(i)
     f.close()

--- a/uni.py
+++ b/uni.py
@@ -1,0 +1,37 @@
+#!/usr/bin/python3
+
+import re
+import sys
+
+
+def uni_file(path, n=0):
+    f = open(path)
+    content = f.readlines()
+    new_content = []
+    for i in content:
+        if (n != 0) and re.match("#+ ", i):
+            new_content.append(n*'#'+i)
+        elif re.match(" \* \[.+\]\(.+\.md\)", i):
+            ref_path = re.search("\(.+\.md\)", i).group()
+            ref_path = ref_path[1:-1]
+            new_content += ['\n']
+            new_content += uni_file(ref_path, n+1)
+        else:
+            new_content.append(i)
+    f.close()
+    return new_content
+
+
+def main():
+    l0_file = [i for i in sys.argv if i.find('/') == -1]
+    new_content = []
+    for i in l0_file:
+        new_content += uni_file(i)
+        new_content += ['\n']
+    f = open("uni.md", "w")
+    f.writelines(new_content)
+    f.close()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
# Problem
- incorrect references
  ![](http://fars.ee/_KWr.png)
- tiled structure
  ![](http://fars.ee/3R_f.png)
# After this commit
- hierarchical structure
  ![](http://fars.ee/7GUS.png)
- no extra incorrect references
  ![](http://fars.ee/x2Af.png)

# Way
1. Using uni.py to scan all first level markdown file and get the reference file paths, replace them with file content, while add '#' before referenced file title line for correct structure, then write the new content to uni.md.
2. Pandoc using pdf/epub.txt and uni.md to generate target file. And delete uni.md finally.