### PR TITLE
use spaced en-dash instead of spaced hyphen

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Uncurled](uncurled.jpg)
 
-**Uncurled** - everything I know and learned about running and maintaining Open
+**Uncurled** – everything I know and learned about running and maintaining Open
 Source projects for three decades.
 
 I have been actively involved in Open Source development since the early 1990s

--- a/emails/ps5.md
+++ b/emails/ps5.md
@@ -42,7 +42,7 @@ about game related problems or services.
     Subject: possible bug
 
     Hi. I didn't find other way to contact with PoB developers, so writing
-    here - please redirect this letter to proper people.
+    here – please redirect this letter to proper people.
     I think i found bug
     when i'm using nightblade support (with dual strike for example) while
     having varunastra equipped (2 obviously), it doesn't add any crit multi

--- a/evolution/tools.md
+++ b/evolution/tools.md
@@ -1,7 +1,7 @@
 # Tools
 
 Independently of what language you write your Open Source in or with, the
-toolchains - usually them too being Open Source - have grown and improved
+toolchains – usually them too being Open Source – have grown and improved
 significantly over the decades.
 
 The tools and editors you write code with are way more advanced.

--- a/intro.md
+++ b/intro.md
@@ -10,7 +10,7 @@ participate.
 I first learned to program on the Commodore 64 as a teenager 1985 and after
 some years I transitioned over to C programming, first on Amiga and then on
 Unix systems. I released my first source code to the public in the early
-1990s - years before the term Open Source was first coined. I have since then
+1990s – years before the term Open Source was first coined. I have since then
 spent many hours every week throughout my entire life contributing to Open
 Source projects, my own and others'. I have worked exclusively with Open
 Source professionally since 2014 for Mozilla and since 2019 for wolfSSL.

--- a/life/health.md
+++ b/life/health.md
@@ -3,7 +3,7 @@
 Health is more important than Open Source. You need to take care of yourself
 and the ones in your vicinity that depend on you, prior to spending time on
 your project. We need to respect that sometimes a contributor vanishes from
-the project - sometimes without saying anything - because of health
+the project – sometimes without saying anything – because of health
 reasons. This includes both physical and mental health.
 
 As a maintainer, people in the project might look up to you to lead and guide

--- a/life/stay-sane.md
+++ b/life/stay-sane.md
@@ -30,7 +30,7 @@ user has a known brand associated with it. Even if that user seems to be upset
 or acts aggressively.
 
 Ask a lot of questions. Figure out how to reproduce. Analyze. Debug. Fix. And
-take it calm. The code is Open Source, your job - even as a maintainer - is
+take it calm. The code is Open Source, your job – even as a maintainer – is
 primarily to aid your users to debug the problem.
 
 ## Aggressive users

--- a/maintain/talks.md
+++ b/maintain/talks.md
@@ -9,7 +9,7 @@ that extra highlight and emphasis.
 Doing a good presentation in a language that probably is not your native
 tongue is not easy and takes a lot of practice to nail. Fortunately, there
 are lots of meetups and local communities in which you can submit talks and
-practice if you want to start out smaller - and in many of them you will be
+practice if you want to start out smaller – and in many of them you will be
 welcomed and cheered at when volunteering to present.
 
 These days, you can even record your own talks and share directly online using

--- a/mine/curl.md
+++ b/mine/curl.md
@@ -8,7 +8,7 @@ almost did what I wanted. I fixed a bug or two in it and sent my improvements
 back to Rafael over email.
 
 Rafael made a few follow-up releases of the tool before he asked if I wanted
-to "take over" maintenance since I had kept on sending improvements his way -
+to "take over" maintenance since I had kept on sending improvements his way –
 and I did.
 
 In August the following year, while still using httpget to get currencies for

--- a/money/companies.md
+++ b/money/companies.md
@@ -3,7 +3,7 @@
 Being in the core team of a popular Open Source project will lead you to
 getting requests to do development for compensation within the realms of that
 project. You will learn that companies are at times willing to pay you to get
-their desired features added in your project so that they can use it - and
+their desired features added in your project so that they can use it – and
 they know that paying an already established core developer is possibly the
 best way to get a feature into a project's mainline code.
 

--- a/money/should-pay.md
+++ b/money/should-pay.md
@@ -13,7 +13,7 @@ baby.
 ## Time is not free
 
 When I talk to or about companies such as the imaginary one above, I try to
-emphasize and underscore that engineering time is not free - not even for
+emphasize and underscore that engineering time is not free – not even for
 them. Their engineers only have a certain amount of time in their work days
 and if the company would pay me to handle my Open Source related matters, I
 would do it (probably) much more effectively and spend less time on it and it

--- a/people/hide-origins.md
+++ b/people/hide-origins.md
@@ -17,5 +17,5 @@ Other reasons for hiding your true name and identity include people who feel
 uncertain that they will be treated badly or at least "unequal" if they
 do. Perhaps the contributor is a member of a minority group, such as
 one with a disability, a follower of an unusual religion or a woman in what is
-a seemingly male-dominated group - which might only appear male-dominated
+a seemingly male-dominated group – which might only appear male-dominated
 because the other women already present are using male-sounding aliases.

--- a/people/negative.md
+++ b/people/negative.md
@@ -8,7 +8,7 @@ you and your community.
 Out of all the feedback you will get to and about a typical project, only a
 small fraction will be positive. Most of the things and features you ship that
 just work will prosper without getting any comments, while you will hear a lot
-about bugs and flaws - both the real kind as well as the ones people think
+about bugs and flaws – both the real kind as well as the ones people think
 exist because they misunderstood something. Being an Open Source project
 maintainer means you should grow thick skin to endure a fair amount of
 criticism.

--- a/people/no-telling.md
+++ b/people/no-telling.md
@@ -13,7 +13,7 @@ perhaps be under the impression that people would tell you these things.
 ## How to find out that someone uses your code
 
 1. The user of your project runs into an issue and asks for help in a project
-   forum - without hiding where they come from or what product they make
+   forum – without hiding where they come from or what product they make
 2. While vanity-searching you find your project's Open Source license
    mentioned for or bundled with a product
 3. A user emails you asking funny questions about a product you never heard of,

--- a/project/bunch.md
+++ b/project/bunch.md
@@ -15,7 +15,7 @@ describing what the project actually does.
 
 The project is rarely a formal or legal entity anywhere, at least as a start.
 Many projects that succeed, later grow up and turn into more formal
-organizations, or join other umbrella organizations to become part of them -
+organizations, or join other umbrella organizations to become part of them –
 and some are even run and owned by companies in the first place that then own
 the name and maybe even associated resources. But some projects remain
 collected solely under that name.

--- a/project/come-and-go.md
+++ b/project/come-and-go.md
@@ -14,7 +14,7 @@ users just suddenly vanish.
 
 The low barrier to entry is also a low barrier to exit. People get bored, they
 change jobs, they find spouses, they get kids, they switch to a competing
-project - in a sense, every other Open Source project in existence is a
+project – in a sense, every other Open Source project in existence is a
 competitor as in they also want the time and energy from contributors and
 every contributor only have their limited amount of time and energy to spend
 on Open Source. If you are unlucky, they spend their precious time in another

--- a/start/attract.md
+++ b/start/attract.md
@@ -9,11 +9,11 @@ Contributor prospects will initially come for the main features and functions
 of your project, but they will not stick around and help out if the "softer"
 areas of the project are not also "attractive" enough. What license is
 used. How high the bar is set for getting started to contribute. But also what
-language is used - both programming and spoken. And when it comes to spoken or
+language is used – both programming and spoken. And when it comes to spoken or
 written language, it means both which language as in English or Spanish and in
 how the specific language is used in issues and discussions and more.
 
 Attracting contributors to a project is about marketing, but you cannot
 lie. You really must deliver on what you claim about your project. By making
-your project appear as nice as possible - because it is - you increase the
+your project appear as nice as possible – because it is – you increase the
 chances of finding users and contributors.

--- a/start/do-it.md
+++ b/start/do-it.md
@@ -9,7 +9,7 @@ users, fellow contributors and it becomes obvious that your project is out
 there.
 
 No one expects it to be perfect to start with. Your work on improving the
-project will be seen as active work on the project - a good thing. Be frank
+project will be seen as active work on the project – a good thing. Be frank
 and open: document the state, explain to your audience what they should and
 could expect from the project as of right now.
 


### PR DESCRIPTION
I'm not sure if such patches dealing with punctuation style are welcome or not. I base my preference for dashes on [English Wikipedia's Manual of Style](https://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style#Dashes):

> #### Punctuating a sentence (em or en dashes)
>
> Dashes are often used to mark divisions within a sentence: in pairs (parenthetical dashes, instead of parentheses or pairs of commas); or singly (perhaps instead of a colon). They may also indicate an abrupt stop or interruption, in reporting quoted speech. [...]
>
> - An em dash is _unspaced_ (with no space on either side):
>   - Another "planet" was detected—but it was later found to be a moon of Saturn.
> - An en dash is _spaced_ (with a space on each side) when used as sentence punctuation:
>   - Another "planet" was detected – but it was later found to be a moon of Saturn.

([permalink](https://en.wikipedia.org/w/index.php?title=Wikipedia:Manual_of_Style&oldid=1091809331#Dashes))