### PR TITLE
Intro: Fix mistake "as a teenager 1985"

### DIFF
--- a/intro.md
+++ b/intro.md
@@ -7,7 +7,7 @@ participated in many more projects and I have of course used and kept myself
 up-to-date with a large number of projects in which I did not personally
 participate.
 
-I first learned to program on the Commodore 64 as a teenager 1985 and after
+I first learned to program on the Commodore 64 as a teenager in 1985 and after
 some years I transitioned over to C programming, first on Amiga and then on
 Unix systems. I released my first source code to the public in the early
 1990s – years before the term Open Source was first coined. I have since then


### PR DESCRIPTION
I'm not a native English speaker, but I believe this a mistake:

> to program [...] as a teenager 1985 and [...]

Corrected by adding "in".